### PR TITLE
Fix/wait user data completion

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -101,8 +101,7 @@ resource "aws_iam_instance_profile" "example" {
   role = aws_iam_role.example.name
 }
 
-resource "aws_instance" "example" {
-  count           = 3
+resource "aws_instance" "master" {
   ami             = "ami-08aa7f71c822e5cc9" # Ubuntu AMI
   instance_type   = "t2.large"
   security_groups = [aws_security_group.control_plane_sg.name]
@@ -112,7 +111,7 @@ resource "aws_instance" "example" {
   }
   iam_instance_profile = aws_iam_instance_profile.example.name
   tags = {
-    Name = "${count.index == 0 ? "master" : "worker-${count.index}"}"
+    Name = "master"
   }
   private_dns_name_options {
     hostname_type = "resource-name"
@@ -125,7 +124,7 @@ resource "aws_instance" "example" {
     sudo apt-get upgrade -y
 
     # Set hostname based on index∫
-    HOSTNAME="${count.index == 0 ? "master" : "worker-${count.index}"}"
+    HOSTNAME="master"
     sudo hostnamectl set-hostname $HOSTNAME
     sudo systemctl restart systemd-hostnamed
 
@@ -175,17 +174,17 @@ resource "aws_instance" "example" {
     echo "installing calico"
     sudo su
     export KUBECONFIG=/etc/kubernetes/admin.conf
-    exit
+    
 
     # Step 6: Install Network Plugin on the Master (Calico)
-    sudo kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.1/manifests/tigera-operator.yaml 
-    sudo kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.1/manifests/custom-resources.yaml
-    sudo kubectl create -f custom-resources.yaml
+    kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.1/manifests/tigera-operator.yaml 
+    kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.1/manifests/custom-resources.yaml
+    kubectl create -f custom-resources.yaml
 
     # watch kubectl get pods --all-namespaces
         # Output the join command for the worker nodes
-    sudo kubeadm token create --print-join-command > /home/ubuntu/kubeadm_join_command.sh
-    sudo chmod +x /home/ubuntu/kubeadm_join_command.sh
+    kubeadm token create --print-join-command > /home/ubuntu/kubeadm_join_command.sh
+    chmod +x /home/ubuntu/kubeadm_join_command.sh
     aws s3 cp /home/ubuntu/kubeadm_join_command.sh s3://${random_pet.bucket_name.id}/kubeadm_join_command.sh
 
     echo "installing ks9 dashboard"
@@ -194,10 +193,10 @@ resource "aws_instance" "example" {
     k9s version
 
     curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-    sudo apt-get install apt-transport-https --yes
+    apt-get install apt-transport-https --yes
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-    sudo apt-get update
-    sudo apt-get install helm
+    apt-get update
+    apt-get install helm
     helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
 
     helm upgrade --install kubernetes-dashboard kubernetes-dashboard/kubernetes-dashboard --create-namespace --namespace kubernetes-dashboard
@@ -212,9 +211,83 @@ resource "aws_instance" "example" {
   EOF
 }
 
-output "instance_public_ips" {
-  value = aws_instance.example[*].public_ip
+resource "aws_instance" "workers" {
+  count           = 2
+  ami             = "ami-08aa7f71c822e5cc9" # Ubuntu AMI
+  instance_type   = "t2.large"
+  security_groups = [aws_security_group.control_plane_sg.name]
+  key_name        = aws_key_pair.deployer.key_name
+  root_block_device {
+    volume_size = 20
+  }
+  iam_instance_profile = aws_iam_instance_profile.example.name
+  tags = {
+    Name = "worker-${count.index + 1}"
+  }
+  private_dns_name_options {
+    hostname_type = "resource-name"
+  }
+  #  to install Client Version: v1.31.0
+  # Kustomize Version: v5.4.2
+  user_data  = <<-EOF
+    #!/bin/bash
+    sudo apt-get update -y
+    sudo apt-get upgrade -y
+
+    # Set hostname based on index∫
+    HOSTNAME="worker-${count.index + 1}"
+    sudo hostnamectl set-hostname $HOSTNAME
+    sudo systemctl restart systemd-hostnamed
+
+    # Install Docker
+    sudo apt-get install -y docker.io
+    sudo systemctl enable docker
+    sudo systemctl start docker
+
+    # Install Kubernetes packages
+    sudo apt-get install -y apt-transport-https ca-certificates curl gpg awscli bash-completion
+    sudo mkdir -p -m 755 /etc/apt/keyrings
+    curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+    # This overwrites any existing configuration in /etc/apt/sources.list.d/kubernetes.list
+    echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+
+
+
+
+    sudo apt-get update
+    sudo apt-get install -y kubelet kubeadm kubectl vim git curl wget 
+    sudo apt-mark hold kubelet kubeadm kubectl
+    sudo systemctl enable --now kubelet
+
+    sudo ufw disable
+    # Disable swap
+    sudo swapoff -a
+    sudo sed -i '/ swap / s/^/#/' /etc/fstab
+    modprobe overlay
+    modprobe br_netfilter
+    echo -e "net.bridge.bridge-nf-call-ip6tables = 1\nnet.bridge.bridge-nf-call-iptables = 1\nnet.ipv4.ip_forward = 1" | sudo tee /etc/sysctl.d/kubernetes.conf
+
+
+
+    sudo systemctl enable kubelet
+    aws s3 cp  s3://${random_pet.bucket_name.id}/kubeadm_join_command.sh /home/ubuntu/kubeadm_join_command.sh
+    sudo ./kubeadm_join_command.sh
+    
+  EOF
+  depends_on = [aws_instance.master]
 }
+
+
+
+output "master_public_ips" {
+  value = aws_instance.master.public_ip
+}
+output "workers_public_ips" {
+  value = aws_instance.workers[*].public_ip
+}
+
 # Generate a random bucket name
 resource "random_pet" "bucket_name" {
   length = 2

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -211,6 +211,12 @@ resource "aws_instance" "master" {
   EOF
 }
 
+provider "time" {}
+
+resource "time_sleep" "wait" {
+  create_duration = "120s" # Waits for 30 seconds
+}
+
 resource "aws_instance" "workers" {
   count           = 2
   ami             = "ami-08aa7f71c822e5cc9" # Ubuntu AMI
@@ -276,7 +282,7 @@ resource "aws_instance" "workers" {
     sudo ./kubeadm_join_command.sh
     
   EOF
-  depends_on = [aws_instance.master]
+  depends_on = [aws_instance.master,time_sleep.wait]
 }
 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -96,6 +96,11 @@ resource "aws_key_pair" "deployer" {
   public_key = file("${path.module}/deployer_key.pub")
 }
 
+resource "aws_iam_instance_profile" "example" {
+  name = "example-instance-profile"
+  role = aws_iam_role.example.name
+}
+
 resource "aws_instance" "example" {
   count           = 3
   ami             = "ami-08aa7f71c822e5cc9" # Ubuntu AMI
@@ -105,7 +110,7 @@ resource "aws_instance" "example" {
   root_block_device {
     volume_size = 20
   }
-
+  iam_instance_profile = aws_iam_instance_profile.example.name
   tags = {
     Name = "${count.index == 0 ? "master" : "worker-${count.index}"}"
   }
@@ -168,7 +173,9 @@ resource "aws_instance" "example" {
     sleep 15
 
     echo "installing calico"
+    sudo su
     export KUBECONFIG=/etc/kubernetes/admin.conf
+    exit
 
     # Step 6: Install Network Plugin on the Master (Calico)
     sudo kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.1/manifests/tigera-operator.yaml 
@@ -179,6 +186,7 @@ resource "aws_instance" "example" {
         # Output the join command for the worker nodes
     sudo kubeadm token create --print-join-command > /home/ubuntu/kubeadm_join_command.sh
     sudo chmod +x /home/ubuntu/kubeadm_join_command.sh
+    aws s3 cp /home/ubuntu/kubeadm_join_command.sh s3://${random_pet.bucket_name.id}/kubeadm_join_command.sh
 
     echo "installing ks9 dashboard"
     curl -sS https://webinstall.dev/k9s | bash
@@ -194,12 +202,12 @@ resource "aws_instance" "example" {
 
     helm upgrade --install kubernetes-dashboard kubernetes-dashboard/kubernetes-dashboard --create-namespace --namespace kubernetes-dashboard
 
+    aws s3 cp  s3://${random_pet.bucket_name.id}/ /home/ubuntu/ --recursive
 
     else
         sudo systemctl enable kubelet
-        sudo mkdir -p $HOME/.kube
-        sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
-        sudo chown $(id -u):$(id -g) $HOME/.kube/config
+        aws s3 cp  s3://${random_pet.bucket_name.id}/kubeadm_join_command.sh /home/ubuntu/kubeadm_join_command.sh
+        sudo ./kubeadm_join_command.sh
     fi
   EOF
 }
@@ -207,49 +215,123 @@ resource "aws_instance" "example" {
 output "instance_public_ips" {
   value = aws_instance.example[*].public_ip
 }
+# Generate a random bucket name
+resource "random_pet" "bucket_name" {
+  length = 2
+}
+resource "aws_s3_bucket" "this" {
+  bucket        = random_pet.bucket_name.id
+  force_destroy = true
+}
 
 
-locals {
-  folders = {
-    "folder1" = {
-      source      = "../simple/"
-      destination = "/home/ubuntu/simple/"
-    }
-    "folder2" = {
-      source      = "../helloHttpd/"
-      destination = "/home/ubuntu/helloHttpd/"
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.bucket
+  versioning_configuration {
+    status = var.versioning ? "Enabled" : "Suspended"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.bucket
 
-# Null resource to handle local folder copy
-resource "null_resource" "copy_folder" {
-  depends_on = [aws_instance.example[0]]
-  for_each = local.folders
-  provisioner "file" {
-    source      = each.value.source
-    destination = each.value.destination
-
-    connection {
-      type        = "ssh"
-      host        = aws_instance.example[0].public_ip
-      user        = "ubuntu"  # 
-      private_key = file("./deployer_key")  #
-    }
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "ls -la ${each.value.destination}",
-    ]
-
-    connection {
-      type        = "ssh"
-      host        = aws_instance.example[0].public_ip
-      user        = "ubuntu"
-      private_key = file("./deployer_key")
-    }
-  }
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
+output "bucket_id" {
+  value = aws_s3_bucket.this.id
+}
+# Upload files recursively from both folders
+resource "aws_s3_bucket_object" "folder1" {
+  for_each = fileset(var.folder1_path, "**/*")
+
+  bucket = aws_s3_bucket.this.id
+  key    = each.key # Corrected: Use only the relative path inside the folder
+  source = "${var.folder1_path}/${each.key}"
+  acl    = "private"
+  etag   = filemd5("${var.folder1_path}/${each.key}")
+}
+
+resource "aws_s3_bucket_object" "folder2" {
+  for_each = fileset(var.folder2_path, "**/*")
+
+  bucket = aws_s3_bucket.this.id
+  key    = each.key # Corrected: Use only the relative path inside the folder
+  source = "${var.folder2_path}/${each.key}"
+  acl    = "private"
+  etag   = filemd5("${var.folder2_path}/${each.key}")
+}
+
+resource "aws_s3_bucket_object" "setup" {
+
+
+  bucket = aws_s3_bucket.this.id
+  key    = "setup_ks8.sh"   # The destination path in S3
+  source = "./setup_ks8.sh" # The path to the file on your local machine
+
+  acl  = "private"
+  etag = filemd5("./setup_ks8.sh")
+}
+
+variable "folder1_path" {
+  type    = string
+  default = "../simple"
+}
+
+variable "folder2_path" {
+  type    = string
+  default = "../helloHttpd"
+}
+variable "versioning" {
+  type    = bool
+  default = false
+}
+
+
+resource "aws_iam_role" "example" {
+  name = "ec2-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        },
+      },
+    ],
+  })
+}
+
+resource "aws_iam_role_policy" "example" {
+  name = "example-policy"
+  role = aws_iam_role.example.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "s3:*",
+        ],
+        Effect   = "Allow",
+        Resource = "*",
+      },
+    ],
+  })
+}

--- a/terraform/setup_ks8.sh
+++ b/terraform/setup_ks8.sh
@@ -51,12 +51,19 @@ sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
 # Step 6: Install Network Plugin on the Master (Calico)
-sudo kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/tigera-operator.yaml 
-sudo kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/custom-resources.yaml
+sudo kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/tigera-operator.yaml 
+sudo kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.25.0/manifests/custom-resources.yaml
 # watch kubectl get pods --all-namespaces
     # Output the join command for the worker nodes
 sudo kubeadm token create --print-join-command > /home/ubuntu/kubeadm_join_command.sh
 sudo chmod +x /home/ubuntu/kubeadm_join_command.sh
+
+aws s3 cp /home/ubuntu/kubeadm_join_command.sh s3://${random_pet.bucket_name.id}/kubeadm_join_command.sh
+
+echo "installing ks9 dashboard"
+curl -sS https://webinstall.dev/k9s | bash
+source ~/.config/envman/PATH.env
+k9s version
 
 curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
 sudo apt-get install apt-transport-https --yes
@@ -66,6 +73,7 @@ sudo apt-get install helm
 helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
 
 helm upgrade --install kubernetes-dashboard kubernetes-dashboard/kubernetes-dashboard --create-namespace --namespace kubernetes-dashboard
+
 
 
 else


### PR DESCRIPTION
following 

[this github issue](https://github.com/hashicorp/terraform/issues/4668)

implemeted a remote exec to tail the user data output to check when done.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactor the Terraform configuration to separate master and worker node setups, introduce IAM instance profiles, and manage Kubernetes setup files using S3. Implement a remote-exec provisioner to ensure user data completion by monitoring cloud-init logs.

New Features:
- Introduce IAM instance profile for EC2 instances to manage permissions more effectively.
- Add S3 bucket creation and management for storing Kubernetes join command and other setup files.
- Implement remote-exec provisioner to wait for user data completion by tailing cloud-init logs.

Enhancements:
- Refactor EC2 instance setup to separate master and worker nodes with distinct configurations.
- Update Kubernetes setup script to use 'kubectl apply' instead of 'kubectl create' for Calico network plugin installation.

<!-- Generated by sourcery-ai[bot]: end summary -->